### PR TITLE
Use correct test base class for integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 _No documentation available about unreleased changes as of yet._
 
+## [1.6.0] Update integration tests and package name
+
+### Changed
+- Fix the integration test base class
+  - Previously, both unit and integration tests used the same base test class. While this worked, integration tests weren't using the polyfilled `WP_UnitTestCase` case from the wp-test-utils package.
+  
+    This, in turn, meant that the tests weren't properly cleaned up, and that some usefull features, like WordPress test factories couldn't be used easily in the integration tests.
+
+    The caveat is that, because of how Pest works, we cannot just define the `uses` statement in the `Pest.php` file, because the WordPress unit test class becomes available after the bootstrap process. For more details see the issue https://github.com/pestphp/pest/issues/623.
+- Change the name of the package to `dingo-d/wp-pest`
+
+None of this is a BC break, as your tests will work. This jsut makes it work a bit better.
+
+## [1.5.0] Updates
+
+### Added
+- Add a `force` parameter to force download WordPress files
+- Add additional tests
+  - Some tests are skipped because they cannot be run in isolation, or the underlying component does type casting.
+
+### Fixed
+- Fix the issue with WP core not being included in the development version
+  - By default, the `wordpress-develop` git repo doesn't contain all the WP Core files,
+     so now we have to download development files for tests and the core separately.
+- Remove unnecessary error checks
+
+### Updated
+- Stubs are updated to mimic WP 6.1.1 version
+
 ## [1.4.1] Fix slug validation
 
 ### Fixed
@@ -45,6 +74,8 @@ _No documentation available about unreleased changes as of yet._
 - Added the functionality for the WordPress integration tests with PestPHP package.
 
 [Unreleased]: https://github.com/dingo-d/wp-pest-integration-test-setup/compare/main...HEAD
+[1.6.0]: https://github.com/https://github.com/dingo-d/wp-pest-integration-test-setup/compare/1.5.0...1.6.0
+[1.5.0]: https://github.com/https://github.com/dingo-d/wp-pest-integration-test-setup/compare/1.4.1...1.5.0
 [1.4.1]: https://github.com/https://github.com/dingo-d/wp-pest-integration-test-setup/compare/1.4.0...1.4.1
 [1.4.0]: https://github.com/https://github.com/dingo-d/wp-pest-integration-test-setup/compare/1.3.0...1.4.0
 [1.3.0]: https://github.com/https://github.com/dingo-d/wp-pest-integration-test-setup/compare/1.2.0...1.3.0

--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ Not running external-http tests. To execute these, use --group external-http.
 
    PASS  Tests\Integration\ExampleTest
   ✓ Rest API endpoints work
+  ✓ Creating terms in category works
 
-  Tests:  1 passed
+  Tests:  2 passed
   Time:   0.14s
 ```
 
@@ -121,7 +122,7 @@ If you want to run the package as a part of your continuous integration (CI) pip
 ### Why such a high PHP version? What if I need to test my theme/plugin on other PHP versions?
 
 Underlying aim of this package (besides getting WordPress developers more acquainted to testing) is to urge the developers to update their projects, and use more modern PHP features. 
-While WordPress supports PHP 5.6, it's no longer even supported with security patches (at the time of writing this PHP 7.3 is in the [EOL phase](https://www.php.net/supported-versions.php)).
+While WordPress supports PHP 5.6, it's no longer even supported with security patches (at the time of writing this PHP 7.4 is in the [EOL phase](https://www.php.net/supported-versions.php)).
 
 The WordPress community needs to move on, and if this package will help somebody to update their servers and PHP version I'll call that a success.
 
@@ -129,12 +130,67 @@ The WordPress community needs to move on, and if this package will help somebody
 
 It's not stuck! 😂 
 
-You're probably running this in WSL, right. For some reason, download on WSL terminal _can_ be slow. When I tested it , it took me some 5-10 minutes to download 30MB file. It took me some 10 seconds on Mac 🤷🏼‍♂️.  
+You're probably running this in WSL, right? For some reason, download on WSL terminal _can_ be slow.  
+This is a [known issue](https://github.com/microsoft/WSL/issues/4901).
+
+The solution is probably to disable some network adapters, as [described here](https://github.com/microsoft/WSL/issues/4901#issuecomment-1192517363) (you can also read a [tl;dr version](https://github.com/microsoft/WSL/issues/4901#issuecomment-1203857953) 😅).
 
 ### It's not working on Windows
 
-I haven't tested it yet on native Windows installation. This is on my to do list.
+I haven't tested it yet on native Windows installation. This is on my to do list, but not high on the priority list.
 
 ### Something is not working
 
 Please do [open an issue](/issues) for that.
+
+## Updates
+
+### 1.6.0 version
+
+I've decided to change the name to a more catchy `wp-pest`. To be honest, not sure why I haven't done this before.
+The functionality stays the same.
+
+If you've just downloaded and set up the testing from scratch on version 1.6.0, then you're all set, happy testing!  
+If not, you should probably update your `phpunit.xml` file to include
+
+```xml
+<env name="WP_TESTS_DIR" value="wp/tests/phpunit"/>
+```
+
+in the `<php>` part of the configuration.
+
+Also, update your `bootstrap.php` file according to the templates in the package. Namely you should remove the line at the end
+
+```php
+require_once dirname(__FILE__, 2) . '/wp/tests/phpunit/includes/bootstrap.php';
+```
+
+with 
+
+```php
+require_once dirname(__DIR__) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
+
+WPIntegration\bootstrap_it();
+```
+
+Make sure you import the namespace for the `bootstrap_it()` function at the top of the file
+
+```php
+use Yoast\WPTestUtils\WPIntegration;
+```
+
+Last, but really important, remove the `Integration` in the `Pest.php` file
+
+```php
+uses(TestCase::class)->in('Unit', 'Integration');
+```
+
+And add
+
+```php
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+uses(TestCase::class);
+```
+
+At the top of every integration test you have. This will ensure a correct base test class is used for integration tests.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "dingo-d/wp-pest-integration-test-setup",
+  "name": "dingo-d/wp-pest",
   "description": "A package that will add WordPress integration test suite with Pest framework",
   "keywords": [
     "php",

--- a/templates/ExampleIntegrationTest.php.tmpl
+++ b/templates/ExampleIntegrationTest.php.tmpl
@@ -2,6 +2,15 @@
 
 namespace Tests\Integration;
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/*
+ * We need to provide the base test class to every integration test.
+ * This will enable us to use all the WordPress test goodies, such as
+ * factories and proper test cleanup.
+ */
+uses(TestCase::class);
+
 beforeEach(function () {
 	parent::setUp();
 
@@ -25,4 +34,16 @@ test('Rest API endpoints work', function () {
 	expect($routes)
 		->toBeArray()
 		->toHaveKey('/wp/v2/posts');
+});
+
+test('Creating terms in category works', function() {
+	$this::factory()->term->create_many(5, [
+		'taxonomy' => 'category',
+	]);
+
+	expect(get_terms([
+		'taxonomy' => 'category',
+		'hide_empty' => false,
+	]))->toBeArray()
+		->toHaveCount(6); // Uncategorized is a default term in the category taxonomy.
 });

--- a/templates/Pest.php.tmpl
+++ b/templates/Pest.php.tmpl
@@ -5,4 +5,4 @@ use Yoast\WPTestUtils\BrainMonkey\TestCase;
 uses()->group('integration')->in('Integration');
 uses()->group('unit')->in('Unit');
 
-uses(TestCase::class)->in('Unit', 'Integration');
+uses(TestCase::class)->in('Unit');

--- a/templates/bootstrap-plugin.php.tmpl
+++ b/templates/bootstrap-plugin.php.tmpl
@@ -1,5 +1,7 @@
 <?php
 
+use Yoast\WPTestUtils\WPIntegration;
+
 // Autoload everything for unit tests.
 $ds = DIRECTORY_SEPARATOR;
 require_once dirname(__FILE__, 2) . $ds . 'vendor' . $ds . 'autoload.php';
@@ -45,10 +47,16 @@ if (isset($GLOBALS['argv']) && in_array('--group=integration', $GLOBALS['argv'],
 	 */
 	function _manually_load_plugin()
 	{
-		require dirname(dirname(__FILE__)) . '/%%%PLUGIN-SLUG%%%.php';
+		require dirname(__DIR__) . '/%%%PLUGIN-SLUG%%%.php';
 	}
 
 	tests_add_filter('muplugins_loaded', '_manually_load_plugin');
 
-	require_once dirname(__FILE__, 2) . '/wp/tests/phpunit/includes/bootstrap.php';
+	require_once dirname(__DIR__) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
+
+	/*
+	 * Bootstrap WordPress. This will also load the Composer autoload file, the PHPUnit Polyfills
+	 * and the custom autoloader for the TestCase and the mock object classes.
+	 */
+	WPIntegration\bootstrap_it();
 }

--- a/templates/bootstrap-theme.php.tmpl
+++ b/templates/bootstrap-theme.php.tmpl
@@ -1,5 +1,7 @@
 <?php
 
+use Yoast\WPTestUtils\WPIntegration;
+
 // Autoload everything for unit tests.
 $ds = DIRECTORY_SEPARATOR;
 require_once dirname(__FILE__, 2) . $ds . 'vendor' . $ds . 'autoload.php';
@@ -66,5 +68,11 @@ if (isset($GLOBALS['argv']) && in_array('--group=integration', $GLOBALS['argv'],
 
 	\tests_add_filter('muplugins_loaded', '_register_theme');
 
-	require_once dirname(__FILE__, 2) . '/wp/tests/phpunit/includes/bootstrap.php';
+	require_once dirname(__DIR__) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
+
+	/*
+	 * Bootstrap WordPress. This will also load the Composer autoload file, the PHPUnit Polyfills
+	 * and the custom autoloader for the TestCase and the mock object classes.
+	 */
+	WPIntegration\bootstrap_it();
 }

--- a/templates/phpunit.xml.tmpl
+++ b/templates/phpunit.xml.tmpl
@@ -13,7 +13,8 @@
 		</testsuite>
 	</testsuites>
 	<php>
-        <env name="TEST" value="true" force="true" />
+		<env name="TEST" value="true" force="true" />
+		<env name="WP_TESTS_DIR" value="wp/tests/phpunit"/>
 		<server name="DB_NAME" value="wp_pest_test_db"/>
 		<server name="DB_USER" value="root"/>
 		<server name="DB_PASSWORD" value=""/>

--- a/tests/Unit/Command/InitCommandTest.php
+++ b/tests/Unit/Command/InitCommandTest.php
@@ -201,7 +201,7 @@ it("checks that the command creates folder with correct templates for a plugin",
 	$bootstrapContents = file_get_contents($bootstrapFilePath);
 
 	expect($bootstrapContents)->toContain("tests_add_filter('muplugins_loaded', '_manually_load_plugin');");
-	expect($bootstrapContents)->toContain("require dirname(dirname(__FILE__)) . '/fake-plugin.php';");
+	expect($bootstrapContents)->toContain("require dirname(__DIR__) . '/fake-plugin.php';");
 
 	// Check if the mock file was unzipped.
 	$wpFolderPath = $this->outputDir . $ds . 'wp' . $ds . 'src' . $ds . 'hello.txt';


### PR DESCRIPTION
## Description

Previously, both unit and integration tests used the same base test class. While this worked, integration tests weren't using the polyfilled WP_UnitTestCase case from the wp-test-utils package.

This, in turn, meant that the tests weren't properly cleaned up and that some usefull features, like WordPress test factories couldn't be used easily in the integration tests.

This commit fixes this issue.

The caveat is that, because of how Pest works, we cannot just define the `uses` statement in the `Pest.php` file, because the WordPress unit test class becomes available after the bootstrap process. For more details see the issue https://github.com/pestphp/pest/issues/623.

## Checklist:
- [x] My code is tested.
- [x] My code follows the code style set by the project.
- [x] I've included documentation for the changes.
